### PR TITLE
Adding 'loadTrix' option

### DIFF
--- a/addon/components/ember-trix.js
+++ b/addon/components/ember-trix.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/ember-trix';
-import _ from 'lodash/lodash';
+import _merge from 'lodash/merge';
 
 const { Trix } = window;
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,5 +2,9 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return { };
+  return {
+    'ember-trix': {
+      loadTrix: true
+    }
+  };
 };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+
 /* jshint node: true */
 'use strict';
 
@@ -9,15 +10,19 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import(
-      path.join(app.bowerDirectory, 'trix/dist/trix.js'),
-      { type: 'vendor' }
-    );
+    let env = this.project.config();
 
-    app.import(
-      path.join(app.bowerDirectory, 'trix/dist/trix.css'),
-      { type: 'vendor' }
-    );
+    if (env['ember-trix'] && env['ember-trix'].loadTrix) {
+      app.import(
+        path.join(app.bowerDirectory, 'trix/dist/trix.js'),
+        { type: 'vendor' }
+      );
+
+      app.import(
+        path.join(app.bowerDirectory, 'trix/dist/trix.css'),
+        { type: 'vendor' }
+      );
+    }
 
     // app.import(
     //   path.join(app.bowerDirectory, 'lodash/lodash.js'),

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.10",
-    "ember-lodash": "^0.0.11"
+    "ember-lodash": "^4.17.5"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Allows user to defer loading of trix JS & CSS until later.

Primary use-case is a Fastboot app: Trix references `navigator` at evaluation time and so is incompatible with Fastboot apps.